### PR TITLE
Add the helm chart directly to the app developer repository

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -1,0 +1,35 @@
+name: Release Charts
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "charts/**"
+
+jobs:
+  release:
+    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          charts_dir: charts
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       -
         name: Generate a Docker image tag
         id: gen_tags
@@ -43,11 +42,9 @@ jobs:
             TAGS='["lindseyvolk/examplepostapp-modernized:latest"]'
           fi
           echo "::set-output name=tags::$TAGS"
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       -
         name: Build and push
         uses: docker/build-push-action@v5
         with:
           push: true
           tags: ${{ fromJson(steps.gen_tags.outputs.tags) }}
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,6 +6,10 @@ name: .NET
 on:
   push:
     branches: [ "main" ]
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+    paths-ignore:
+      - 'charts/**'
   pull_request:
     branches: [ "main" ]
 
@@ -28,9 +32,22 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      -
+        name: Generate a Docker image tag
+        id: gen_tags
+        run: |
+          if [[ $GITHUB_REF == 'refs/tags/v'* ]]; then
+            TAGS='["lindseyvolk/examplepostapp-modernized:latest","lindseyvolk/examplepostapp-modernized:'${GITHUB_REF/refs\/tags\//}'"]'
+          else
+            TAGS='["lindseyvolk/examplepostapp-modernized:latest"]'
+          fi
+          echo "::set-output name=tags::$TAGS"
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       -
         name: Build and push
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: lindseyvolk/examplepostapp-modernized:latest
+          tags: ${{ fromJson(steps.gen_tags.outputs.tags) }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -33,18 +33,21 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Generate a Docker image tag
-        id: gen_tags
-        run: |
-          if [[ $GITHUB_REF == 'refs/tags/v'* ]]; then
-            TAGS='["lindseyvolk/examplepostapp-modernized:latest","lindseyvolk/examplepostapp-modernized:'${GITHUB_REF/refs\/tags\//}'"]'
-          else
-            TAGS='["lindseyvolk/examplepostapp-modernized:latest"]'
-          fi
-          echo "::set-output name=tags::$TAGS"
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            lindseyvolk/examplepostapp-modernized
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
       -
         name: Build and push
         uses: docker/build-push-action@v5
         with:
-          push: true
-          tags: ${{ fromJson(steps.gen_tags.outputs.tags) }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/charts/modern-post-application/.helmignore
+++ b/charts/modern-post-application/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/modern-post-application/Chart.yaml
+++ b/charts/modern-post-application/Chart.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v2
+name: modern-post-application
+description: A helm chart to deploy the Modern Post Application as an containerized Deployment
+type: application
+version: 0.1.0
+appVersion: 0.1.0

--- a/charts/modern-post-application/templates/NOTES.txt
+++ b/charts/modern-post-application/templates/NOTES.txt
@@ -1,0 +1,24 @@
+1. Get the application URL below or by running these commands:
+{{- if .Values.route.enabled }}
+{{- if .Values.route.host }}
+  http{{ if $.Values.route.tls }}s{{ end }}://{{ .Values.route.host }}
+{{- else if and .Values.route.baseDomain .Values.route.clusterName }}
+  http{{ if $.Values.route.tls }}s{{ end }}://{{ include "modern-post-application.fullname" }}-{{ .Release.Namespace }}.apps.{{ .Values.route.clusterName }}.{{ .Values.route.baseDomain }}
+{{- else }}
+  echo http{{ if $.Values.route.tls }}s{{ end }}://$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.status.ingress[].host}" routes {{ include "modern-post-application.fullname" . }})
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "modern-post-application.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "modern-post-application.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "modern-post-application.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.route 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "modern-post-application.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/modern-post-application/templates/_helpers.tpl
+++ b/charts/modern-post-application/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "modern-post-application.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "modern-post-application.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "modern-post-application.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "modern-post-application.labels" -}}
+helm.sh/chart: {{ include "modern-post-application.chart" . }}
+{{ include "modern-post-application.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "modern-post-application.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "modern-post-application.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "modern-post-application.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "modern-post-application.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/modern-post-application/templates/deployment.yaml
+++ b/charts/modern-post-application/templates/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "modern-post-application.fullname" . }}
+  labels:
+    {{- include "modern-post-application.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "modern-post-application.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "modern-post-application.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "modern-post-application.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "modern-post-application.fullname" . }}-env
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/modern-post-application/templates/deployment.yaml
+++ b/charts/modern-post-application/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/modern-post-application/templates/environment.yaml
+++ b/charts/modern-post-application/templates/environment.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.postCode }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "modern-post-application.fullname" . }}-env
+  labels:
+    {{- include "modern-post-application.labels" . | nindent 4 }}
+data:
+  {{- with .Values.postCode }}
+  POST_CD: {{ toYaml . }}
+  {{- end }}
+{{- end }}

--- a/charts/modern-post-application/templates/hpa.yaml
+++ b/charts/modern-post-application/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "modern-post-application.fullname" . }}
+  labels:
+    {{- include "modern-post-application.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "modern-post-application.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/modern-post-application/templates/route.yaml
+++ b/charts/modern-post-application/templates/route.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.route.enabled -}}
+{{- $fullName := include "modern-post-application.fullname" . -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "modern-post-application.labels" . | nindent 4 }}
+  {{- with .Values.route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.route.host }}
+  host: {{ quote . }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ $fullName }}
+    weight: 100
+  port:
+    targetPort: {{ .Values.service.port }}
+  {{- with .Values.route.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  wildcardPolicy: None
+{{- end }}

--- a/charts/modern-post-application/templates/service.yaml
+++ b/charts/modern-post-application/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "modern-post-application.fullname" . }}
+  labels:
+    {{- include "modern-post-application.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "modern-post-application.selectorLabels" . | nindent 4 }}

--- a/charts/modern-post-application/templates/serviceaccount.yaml
+++ b/charts/modern-post-application/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "modern-post-application.serviceAccountName" . }}
+  labels:
+    {{- include "modern-post-application.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/modern-post-application/values.yaml
+++ b/charts/modern-post-application/values.yaml
@@ -1,0 +1,55 @@
+---
+replicaCount: 1
+
+postCode: TRT.PROD
+
+image:
+  registry: docker.io
+  repository: lindseyvolk/examplepostapp-modernized
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext:
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+
+service:
+  type: ClusterIP
+  port: 8080
+
+route:
+  enabled: true
+  annotations: {}
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+
+resources: {}
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This PR introduces a Helm Chart designed to deploy the containerize application onto OpenShift and use the built-in OpenShift Router for Ingress.

Because the Chart artifacts are strongly versioned, an additional change was required to the container image build workflow to generate Docker image tags based on Git tags. The workflow for the image build was updated to also run on all tag events (as well as pushes to main), and will push to the `:latest` tag on all main pushes as well as to the `:vX.Y.Z` tag when a corresponding Git tag is created and pushed.

Because the Chart is colocated with the application code itself, the Chart's publish workflow was configured to only react to changes to files inside the charts subdirectory and the application's workflow was updated to ignore this directory entirely.

The chart itself has been tested, this GitHub Workflow hasn't - there might be some logic errors to clean up.

Merge whenever you've had a chance to look over it, and then feel free to pull main, tag with `v0.1.0`, and push that tag - the Chart should immediately work at that point, with no change in values necessary. To test the Chart beforehand, just set image.tag to latest when applying it.